### PR TITLE
added custom CSS to handle tabs

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -4,3 +4,8 @@ div.left-0:nth-child(2) {
 aside ul:nth-child(3) {
   margin-top: 1em;
 }
+
+.flex.border {
+    overflow-x: auto;
+    white-space: nowrap;
+}


### PR DESCRIPTION
![image](https://github.com/anotherduckling/Wotaku/assets/139688370/ab333f2c-f9b5-416f-9569-da4f07f74218)

This custom CSS tries to fix the issue as seen in the image above, where on mobile (or on smaller screens) the tabs aren't responsive. the CSS makes the tab container scrollable.