### PR TITLE
fix: vertically align badges with icons to center

### DIFF
--- a/.vitepress/theme/components/Badge.vue
+++ b/.vitepress/theme/components/Badge.vue
@@ -36,6 +36,7 @@ withDefaults(defineProps<Props>(), {
   align-items: center;
   gap: 0.2rem;
   padding-right: 10px;
+  vertical-align: middle;
 }
 
 .vp-doc h1 > .VPBadge {


### PR DESCRIPTION
Adds `vertical-align: middle` to badges. Currently badges with icons are misaligned because the empty `div` for the badge icon does not have a valid baseline:

<img width="977" alt="image" src="https://github.com/anotherduckling/Wotaku/assets/96655713/4663e1dd-dda0-4bcc-9282-fa659195b800">

This PR changes it to:

<img width="971" alt="image" src="https://github.com/anotherduckling/Wotaku/assets/96655713/c6990d6d-8f91-4720-89df-6ae141aa68d8">

If you must keep the baseline alignment, another option is to make the `div` non-empty (with the height unset as well) so that there is valid baseline:
```html
<template>
  <component
    :target="link ? '_blank' : undefined"
    :is="link ? 'a' : 'span'"
    class="VPBadge"
    :class="link ? 'tip' : type"
    :href="link">
    <div v-if="icon" :class="icon" style="height: unset;">
      <span style="color: transparent;">A</span>
    </div>
    <slot>{{ text }}</slot>
  </component>
</template>
```